### PR TITLE
Usuários: Editar

### DIFF
--- a/app/GraphQL/Mutations/UserMutation.php
+++ b/app/GraphQL/Mutations/UserMutation.php
@@ -23,4 +23,22 @@ class UserMutation
 
         return $user;
     }
+
+    /**
+     * @param  null  $_
+     * @param  array<string, mixed>  $args
+     */
+    public function edit($rootValue, array $args, GraphQLContext $context)
+    {
+        if (strlen($args['password']) < 6) {
+            throw new \Exception('Password must be at least 6 characters');
+        }
+
+        $args['password'] = Hash::make($args['password']);
+
+        $user = \App\Models\User::findOrFail($args['id']);
+        $user->update($args);
+
+        return $user;
+    }
 }

--- a/app/GraphQL/Validators/Mutation/UserEditValidator.php
+++ b/app/GraphQL/Validators/Mutation/UserEditValidator.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\GraphQL\Validators\Mutation;
+
+use Nuwave\Lighthouse\Validation\Validator;
+
+final class UserEditValidator extends Validator
+{
+    /**
+     * Return the validation rules.
+     *
+     * @return array<string, array<mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'password' => [
+                'required',
+                'min:6',
+            ],
+            'email' => [
+                'unique:users,email,' . $this->arg('id'),
+                'required',
+                'email',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'password.required' => trans('UserEdit.password_required'),
+            'password.min' => trans('UserEdit.password_min_6'),
+            'email.required' => trans('UserEdit.email_required'),
+            'email.email' => trans('UserEdit.email_is_valid'),
+            'email.unique' => trans('UserEdit.email_unique'),
+        ];
+    }
+}

--- a/graphql/user/UserMutation.graphql
+++ b/graphql/user/UserMutation.graphql
@@ -6,4 +6,12 @@ extend type Mutation {
         password: String! @rules(apply: ["min:6"])
     ): User
     @field(resolver: "UserMutation@create") @validator
+
+    userEdit(
+        id: ID!
+        name: String!
+        email: String!
+        password: String! @rules(apply: ["min:6"])
+    ): User
+    @field(resolver: "UserMutation@edit") @validator
 }

--- a/lang/en/UserEdit.php
+++ b/lang/en/UserEdit.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during authentication for various
+    | messages that we need to display to the user. You are free to modify
+    | these language lines according to your application's requirements.
+    |
+    */
+
+    'email_is_valid' => 'The email field must be a valid email address.',
+    'email_required' => 'The email field is required.',
+    'email_unique' => 'This email has already been registered.',
+    'password_min_6' => 'The password must be at least 6 characters long.',
+    'password_required' => 'The password field is required.',
+
+];

--- a/lang/pt-br/UserEdit.php
+++ b/lang/pt-br/UserEdit.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during authentication for various
+    | messages that we need to display to the user. You are free to modify
+    | these language lines according to your application's requirements.
+    |
+    */
+
+    'email_is_valid' => 'O campo e-mail deve ser um e-mail válido.',
+    'email_required' => 'O campo e-mail é obrigatório.',
+    'email_unique' => 'Este e-mail já foi registrado.',
+    'password_min_6' => 'A senha precisa ter no mínimo 6 caracteres.',
+    'password_required' => 'O campo senha é obrigatório.',
+
+];


### PR DESCRIPTION
### O que?

Adicionado opção de editar informações dos usuários.

### Por quê?

Para poder editar as informações do usuário.

### Como?

Criado end-point em graphql para editar as informações do usuário.

### Testes

Feito todos os casos de teste para validações da edição, feito apenas testes funcionais dos end-points

![image](https://user-images.githubusercontent.com/25940408/169736541-ff0b5a29-4372-4cc3-bb1f-7fc3efcf41ac.png)
